### PR TITLE
Removing limit for railties version

### DIFF
--- a/weather-icons-rails.gemspec
+++ b/weather-icons-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir["test/**/*"]
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "railties", ">= 3.2", "< 5.0"
+  gem.add_dependency "railties", ">= 3.2"
 
   gem.add_development_dependency 'activesupport', '~> 4.1.0'
   gem.add_development_dependency 'sass-rails', '~> 4.0.1'


### PR DESCRIPTION
I removed the limit for a railties version.  This allows this gem to be used with the latest version of rails and railties.  I tested this and it seems to work fine.